### PR TITLE
Add Teller and Assemble to the footer

### DIFF
--- a/themes/keycard/layout/partial/footer.ejs
+++ b/themes/keycard/layout/partial/footer.ejs
@@ -69,11 +69,13 @@
           <p class="h6">The Status Network</p>
           <ul class="o-list">
             <li><a href="https://status.im/" title="<%= __('footer.status.links.status') %>" target="_blank">Status</a></li>
-            <li><a href="https://embark.status.im/" title="Embark" target="_blank">Embark</a></li>
-            <li><a href="https://nimbus.status.im/" title="Nimbus" target="_blank">Nimbus</a></li>
             <li><a href="https://dap.ps/" title="dap.ps" target="_blank">dap.ps</a></li>
+            <li><a href="https://teller.exchange/" title="Teller" target="_blank">Teller</a></li>
+            <li><a href="https://assemble.fund/" title="Assemble" target="_blank">Assemble</a></li>
+            <li><a href="https://embark.status.im/" title="Embark" target="_blank">Embark</a></li>
             <li><a href="https://subspace.status.im/" title="Subspace" target="_blank">Subspace</a></li>
             <li><a href="https://vac.dev/" title="Vac" target="_blank">Vac</a></li>
+            <li><a href="https://nimbus.status.im/" title="Nimbus" target="_blank">Nimbus</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
add Teller and Assemble to the footer
<img width="315" alt="Screen Shot 2020-01-23 at 11 30 22 PM" src="https://user-images.githubusercontent.com/41753422/72993410-ad9c1700-3e38-11ea-838b-b28580fdae10.png">

The order of the Status Network projects is

Products
Dev Tools
Infra
(Suggested by Jonny)


