### PR TITLE
rename get.status.im to join.status.im

### DIFF
--- a/source/docs/index.md
+++ b/source/docs/index.md
@@ -26,6 +26,6 @@ The current version of the applet is 3.0. This documentation applies to said ver
 You are at the right place to find informations about Keycard and get you going. 
 
 If you need more and want to discuss:
-- for live discussion and help, go to [Keycard Status channel](https://get.status.im/chat/public/status-keycard)
+- for live discussion and help, go to [Keycard Status channel](https://join.status.im/chat/public/status-keycard)
 - to check or raise issues/bugs/feature requests please do so in our [GitHub repos](https://status.im/keycard_api/resources.html)
 - check our latest Keycard news on [Discuss](https://discuss.status.im/c/keycard)

--- a/themes/keycard/languages/en.yml
+++ b/themes/keycard/languages/en.yml
@@ -88,7 +88,7 @@ about:
   block:
     opensource:
       title: An <strong>Open Source Project</strong>
-      subtitle: Keycard is an entirely open source project built by core contributors and an active community. <br/><br/>Check out the <a href="https://github.com/status-im/status-keycard" target="_blank" title="Github Repo">GitHub Repo</a> or <a href="http://get.status.im/chat/public/status-keycard" title="Chat in Status" target="_blank">Join the chat in Status.
+      subtitle: Keycard is an entirely open source project built by core contributors and an active community. <br/><br/>Check out the <a href="https://github.com/status-im/status-keycard" target="_blank" title="Github Repo">GitHub Repo</a> or <a href="http://join.status.im/chat/public/status-keycard" title="Chat in Status" target="_blank">Join the chat in Status.
     contributions:
       title: The <strong>Core Contributors</strong>
       subtitle: We’re a diverse group of engineers with expertise in hardware, security, and web3 technology

--- a/themes/keycard/layout/about-us.ejs
+++ b/themes/keycard/layout/about-us.ejs
@@ -29,7 +29,7 @@
                   <a href="https://github.com/gravityblast" target="_blank" title="<%= __('about.block.contributions.people.githublinktext') %>"><%= __('about.block.contributions.people.githublinktext') %></a>
                 </li>
                 <li>
-                  <a href="https://get.status.im/user/0x04b40ac542157ab4e6cf09a2bad5a12ade51d809cc079de1facaa45aaebfb272b0ed64b9b5275877f367127179d972149a294ecc2a78fc8d4688438f5730d8828a" target="_blank" title="<%= __('about.block.contributions.people.statuslinktext') %>"><%= __('about.block.contributions.people.statuslinktext') %></a>
+                  <a href="https://join.status.im/user/0x04b40ac542157ab4e6cf09a2bad5a12ade51d809cc079de1facaa45aaebfb272b0ed64b9b5275877f367127179d972149a294ecc2a78fc8d4688438f5730d8828a" target="_blank" title="<%= __('about.block.contributions.people.statuslinktext') %>"><%= __('about.block.contributions.people.statuslinktext') %></a>
                 </li>
               </ul>
           </div>
@@ -44,7 +44,7 @@
                   <a href="https://github.com/guylouis" target="_blank" title="<%= __('about.block.contributions.people.githublinktext') %>"><%= __('about.block.contributions.people.githublinktext') %></a>
                 </li>
                 <li>
-                  <a href="https://get.status.im/user/0x04204474d2e3d064c566e1a03a1c1d92902fd4b986c882d988f6632cbe0677c85116100af41a4b7467c01bd5a15121216616e273f4c3c77e3a99f936f9456a62f7" target="_blank" title="<%= __('about.block.contributions.people.statuslinktext') %>"><%= __('about.block.contributions.people.statuslinktext') %></a>
+                  <a href="https://join.status.im/user/0x04204474d2e3d064c566e1a03a1c1d92902fd4b986c882d988f6632cbe0677c85116100af41a4b7467c01bd5a15121216616e273f4c3c77e3a99f936f9456a62f7" target="_blank" title="<%= __('about.block.contributions.people.statuslinktext') %>"><%= __('about.block.contributions.people.statuslinktext') %></a>
                 </li>
               </ul>
           </div>
@@ -59,7 +59,7 @@
                 <a href="https://github.com/bitgamma" target="_blank" title="<%= __('about.block.contributions.people.githublinktext') %>"><%= __('about.block.contributions.people.githublinktext') %></a>
               </li>
               <li>
-                <a href="https://get.status.im/user/0x0472b0f0f58ef9f3275874bb72ab1db784486ec7bd68cda8f658410fbbf1427a9b384bc921299df1974f1786a83b6d515c2fe413273f593e5ecbd794dabd025292" target="_blank" title="<%= __('about.block.contributions.people.statuslinktext') %>"><%= __('about.block.contributions.people.statuslinktext') %></a>
+                <a href="https://join.status.im/user/0x0472b0f0f58ef9f3275874bb72ab1db784486ec7bd68cda8f658410fbbf1427a9b384bc921299df1974f1786a83b6d515c2fe413273f593e5ecbd794dabd025292" target="_blank" title="<%= __('about.block.contributions.people.statuslinktext') %>"><%= __('about.block.contributions.people.statuslinktext') %></a>
               </li>
             </ul>
           </div>
@@ -74,7 +74,7 @@
                 <a href="https://github.com/hesterbruikman" target="_blank" title="<%= __('about.block.contributions.people.githublinktext') %>"><%= __('about.block.contributions.people.githublinktext') %></a>
               </li>
               <li>
-                <a href="https://get.status.im/user/0x045f63aeab1acb3c0bc54d3665a6423c128139f7b9b217c532fbe8a2d0dbb4c6b51f3dfe5519f43a2cd60e4c57243599146ceab56a651f68b2067e840a606d3266" target="_blank" title="<%= __('about.block.contributions.people.statuslinktext') %>"><%= __('about.block.contributions.people.statuslinktext') %></a>
+                <a href="https://join.status.im/user/0x045f63aeab1acb3c0bc54d3665a6423c128139f7b9b217c532fbe8a2d0dbb4c6b51f3dfe5519f43a2cd60e4c57243599146ceab56a651f68b2067e840a606d3266" target="_blank" title="<%= __('about.block.contributions.people.statuslinktext') %>"><%= __('about.block.contributions.people.statuslinktext') %></a>
               </li>
             </ul>
           </div>

--- a/themes/keycard/layout/partial/footer.ejs
+++ b/themes/keycard/layout/partial/footer.ejs
@@ -33,7 +33,7 @@
               </a>
             </li>
             <li>
-              <a href="https://get.status.im/chat/public/status-keycard" title="Status" target="_blank">
+              <a href="https://join.status.im/chat/public/status-keycard" title="Status" target="_blank">
                 <svg width="35" height="34" viewBox="0 0 35 34" fill="none" xmlns="http://www.w3.org/2000/svg" class="icon icon--small">
                   <path fill-rule="evenodd" clip-rule="evenodd" d="M17.3333 0C7.76038 0 0 7.61126 0 17C0 26.3889 7.76038 34 17.3333 34C26.9063 34 34.6667 26.3889 34.6667 17C34.6667 7.61126 26.9063 0 17.3333 0Z" fill="white"/>
                   <path fill-rule="evenodd" clip-rule="evenodd" d="M17.9154 16.2546C18.7858 16.3435 19.6562 16.4323 20.7263 16.3739C23.6255 16.2154 25.3818 14.7559 25.2571 12.5744C25.1301 10.3548 22.7936 8.98732 20.4559 9.11518C16.6461 9.32337 13.8445 12.6039 13.529 16.3534C14.0464 16.2345 14.5909 16.1635 15.1045 16.1355C16.1747 16.077 17.045 16.1658 17.9154 16.2546ZM10.4469 21.107C10.5671 23.1416 12.7807 24.3951 14.9955 24.2779C18.6047 24.087 21.259 21.0799 21.5578 17.6429C21.0676 17.7519 20.5518 17.817 20.0652 17.8427C19.0514 17.8963 18.2267 17.8149 17.4021 17.7334C16.5775 17.652 15.7529 17.5706 14.7391 17.6242C11.9926 17.7695 10.3287 19.1072 10.4469 21.107Z" fill="#0E1C36"/>
@@ -61,7 +61,7 @@
         <div class="o-grid__column-1-2 o-grid__column-large-1-4 o-grid__column-xlarge-1-5">
           <p class="h6"><%= __('footer.resources.title') %></p>
           <ul class="o-list">
-            <li><a href="http://get.status.im/chat/public/status-keycard" title="<%= __('footer.resources.links.contact') %>" target="_blank"><%= __('footer.resources.links.contact') %></a></li>
+            <li><a href="http://join.status.im/chat/public/status-keycard" title="<%= __('footer.resources.links.contact') %>" target="_blank"><%= __('footer.resources.links.contact') %></a></li>
             <li><a href="https://status.im/privacy-policy" target="_blank" title="<%= __('footer.resources.links.privacy') %>" target="_blank"><%= __('footer.resources.links.privacy') %></a></li>
           </ul>
         </div>


### PR DESCRIPTION
I've renamed the https://get.status.im/ site to https://join.status.im/ in https://github.com/status-im/infra-misc/commit/d4784edd.

The old links should work due to a CloudFlare HTTP redirect I deployed, but I think a URL like:
https://join.status.im/user/jakubgs
Reads much better as a sentence, which literally reads as "Join Status.im user Jakubgs".