### PR TITLE
add JS script for passing around ad_id URL parameter

### DIFF
--- a/themes/keycard/layout/partial/footer.ejs
+++ b/themes/keycard/layout/partial/footer.ejs
@@ -54,10 +54,10 @@
         <div class="o-grid__column-1-2 o-grid__column-large-1-4 o-grid__column-xlarge-1-5">
           <p class="h6"><%= __('footer.documentation.title') %></p>
           <ul class="o-list">
-            <li><a href="https://keycard.tech/docs/" target="_blank" title="<%= __('footer.documentation.links.started') %>"><%= __('footer.documentation.links.started') %></a></li>
-            <li><a href="https://keycard.tech/docs/sdk/" title="<%= __('footer.documentation.links.java') %>" target="_blank"><%= __('footer.documentation.links.java') %></a></li>
+            <li><a href="/docs/" target="_blank" title="<%= __('footer.documentation.links.started') %>"><%= __('footer.documentation.links.started') %></a></li>
+            <li><a href="/docs/sdk/" title="<%= __('footer.documentation.links.java') %>" target="_blank"><%= __('footer.documentation.links.java') %></a></li>
             <li><a href="https://github.com/status-im/keycard-go/" title="<%= __('footer.documentation.links.go') %>" target="_blank"><%= __('footer.documentation.links.go') %></a></li>
-            <li><a href="https://keycard.tech/docs/apdu/" title="<%= __('footer.documentation.links.protocol') %>" target="_blank"><%= __('footer.documentation.links.protocol') %></a></li>
+            <li><a href="/docs/apdu/" title="<%= __('footer.documentation.links.protocol') %>" target="_blank"><%= __('footer.documentation.links.protocol') %></a></li>
           </ul>
         </div>
         <div class="o-grid__column-1-2 o-grid__column-large-1-4 o-grid__column-xlarge-1-5">
@@ -102,10 +102,8 @@
     </div>
   </footer>
 </div>
-  <script
-  src="https://code.jquery.com/jquery-3.3.1.min.js"
-  integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
-  crossorigin="anonymous"></script>
+  <script src="/javascripts/adparam.js"></script>
+  <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
 
 <script>
   /*!

--- a/themes/keycard/layout/partial/header.ejs
+++ b/themes/keycard/layout/partial/header.ejs
@@ -13,21 +13,21 @@
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon"><title>close</title><path d="M14.3,12.179a.25.25,0,0,1,0-.354l9.263-9.262A1.5,1.5,0,0,0,21.439.442L12.177,9.7a.25.25,0,0,1-.354,0L2.561.442A1.5,1.5,0,0,0,.439,2.563L9.7,11.825a.25.25,0,0,1,0,.354L.439,21.442a1.5,1.5,0,0,0,2.122,2.121L11.823,14.3a.25.25,0,0,1,.354,0l9.262,9.263a1.5,1.5,0,0,0,2.122-2.121Z"/></svg>
               </a>
               <% if (is_home()) { %>
-                <a href="<%- config.url %>/<%- show_lang() %>#features" title="<%- __('header.menu.features.title') %>"
+                <a href="/<%- show_lang() %>#features" title="<%- __('header.menu.features.title') %>"
                   class="o-navigation__item js-anchor-scroll">
                   <%- __('header.menu.features.title') %>
                 </a>
-                <a href="<%- config.url %>/<%- show_lang() %>#security" title="<%- __('header.menu.security.title') %>"
+                <a href="/<%- show_lang() %>#security" title="<%- __('header.menu.security.title') %>"
                   class="o-navigation__item js-anchor-scroll">
                   <%- __('header.menu.security.title') %>
                 </a>
               <% } %>
               <% if (!is_home()) { %>
-                <a href="<%- config.url %>/<%- show_lang() %>#features" title="<%- __('header.menu.features.title') %>"
+                <a href="/<%- show_lang() %>#features" title="<%- __('header.menu.features.title') %>"
                   class="o-navigation__item">
                   <%- __('header.menu.features.title') %>
                 </a>
-                <a href="<%- config.url %>/<%- show_lang() %>#security" title="<%- __('header.menu.security.title') %>"
+                <a href="/<%- show_lang() %>#security" title="<%- __('header.menu.security.title') %>"
                   class="o-navigation__item">
                   <%- __('header.menu.security.title') %>
                 </a>

--- a/themes/keycard/source/javascripts/adparam.js
+++ b/themes/keycard/source/javascripts/adparam.js
@@ -1,0 +1,34 @@
+/* name of the URL parameter passed by advertisement campaigns */
+const AD_ID_PARAM = 'p'
+
+/* returns the URL parameter value or null */
+const getAdID = () => (new URLSearchParams(document.location.search)).get(AD_ID_PARAM)
+
+/* checks if links are relative or reference keycard.tech */
+const isInternalLink = (element) => {
+  let url = element.getAttribute('href')
+  return url.startsWith('/') || url.includes('keycard.tech')
+}
+
+const setAdIDParam = (id, element) => {
+  let url = new URL(element.getAttribute('href'), document.location.origin)
+  url.searchParams.set(AD_ID_PARAM, id)
+  element.setAttribute('href', url.toString())
+}
+
+const addAdIDToLinks = (id) => {
+  elements = document.querySelectorAll('a')
+  /* filter out non-internal links */
+  cleanList = [...elements].filter(isInternalLink)
+  /* set the AD campaign ID for all internal links */
+  cleanList.forEach((element, idx) => setAdIDParam(id, element))
+}
+
+(function() {
+  let id = getAdID()
+  /* we modify links only if our parameter is set. */
+  if (id == null) { return }
+  /* iterate over all <a> tags and update URLs
+   * with AD parameter where necessary */
+  addAdIDToLinks(id)
+})()


### PR DESCRIPTION
This essentially passes the `ad_id` URL parameter to `get.keycard.tech`, but also makes it stay in the URL while the user browses the `keycard.tech` site by modifying all local URLs to include `ad_id`.