### PR TITLE
edit FAQ

### DIFF
--- a/source/_data/faq.yml
+++ b/source/_data/faq.yml
@@ -3,78 +3,78 @@
   list: 
     - question: What is Keycard for?
       list:
-        - Keycard is hardware wallet that you can use with your Status app.
-        - It provides a higher level of security and ownership to Status user of their private keys. Keycard is a cold storage for your assets that you need to tap (along with entering a pin) on your phone when making a transaction.
-        - And Keycard can be used a 2FA to protect access to your Status account. To login your account you will need to tap your card and enter your PIN
+        - Keycard is a hardware wallet that integrates with Status. Secure your transactions by tapping your Keycard on your phone.
+        - Keycard provides security and ownership. You control your private keys.
+        - Keycard is 2FA - tap your Keycard to login to your Status account.
 
     - question: Is Keycard available with Status on Android and iOS?
-      text: Keycard is currently only available on Android to use with Status. The Keycard team is currently working on iOS integration.
+      text: Keycard is currently only available for Status on Android. The Keycard team is currently working on iOS integration.
     
     - question: How much does Keycard cost?
-      text: Keycard costs 29€ Retail and can be purchased here.
+      text: Keycard costs 24.9€ Retail and can be purchased here - https://get.keycard.tech/
     
     - question: Can I use Keycard as a debit/credit card to make payments?
-      text: For now Keycard can be used by Status user as hardware wallet only. It is part of our roadmap to introduce physical payments with Keycard as part of an open, inclusive and permissionless payment network where payment terminals are any phone running Status.
+      text: For now, Keycard is only a hardware wallet. It is part of our roadmap to introduce physical payments with Keycard as part of an open, inclusive and permissionless payment network where any phone running Status can act as a payment terminal.
 
     - question: How is Keycard different from other hardware wallets like Ledger or Trezor?
-      text: Keycard is from the ground up built like a mobile friendly hardware wallet. It embeds NFC contactless technology to communicate with your mobile phone and sign transaction with a tap of the card and entering your keycard PIN code. Moreover its form factor is very convenient to carry around. Keycard does not have a screen or keyboard, making it cost effective. The security level of Keycard is similar to a Ledger when used with trusted application like Status.
+      text: Keycard is build from the ground up as a mobile friendly hardware wallet. It uses contactless NFC technology to communicate with your phone, and sign transactions with a tap of the card. It's also convenient, lightweight, it fits in your wallet, pocket, phone case, practically anywhere. Keycard offers similar security to wallets like Ledger when used with trusted applications like Status.
 
     - question: Is Keycard integrated with any other wallets?
-      text: Status is the first production integration with Keycard. However, developers can integrate Keycard with their products with the Open Source Keycard API available here.
+      text: Not yet. However, developers can easily integrate with Keycard using the Open Source Keycard API available here - https://keycard.tech/docs/ 
 
-    - question: Which assets does Keycard supports?
-      text: Status app can be used with Keycard and supports Ethereum assets (eth, erc-20, nfts). Keycard itself supports ecdsa secp256k1 signatures, so if you're a wallet developper you can integrate Keycard with any other blockchain that uses secp256k1 ecdsa signatures including of course bitcoin. 
+    - question: Which assets does Keycard support?
+      text: Keycard supports ecdsa secp256k1 signatures, so it can be integrated with any other blockchain that uses them (including Bitcoin, of course!). However, if you are using Keycard with Status you will be limited to the blockchains that Status supports.
 
 - security:
   title: Security
   list: 
-    - question: Are my funds safe if I lost my Keycard?
-      text: If you lost your keycard, your funds are safe. To use your keycard on a phone you do not own (and thus haven't paired the keycard with) one needs your pairing code and your 6 digits pass code to access your funds. You can recover your funds with Status or any other wallet by using your mnemonic.  
-    
+    - question: Are my funds safe if I lose my Keycard?
+      text: If you lose your keycard, your funds are safe. Your pairing code and 6 digit passcode are both required to access your funds from a phone that isn't paired with your Keycard. Your funds can be recovered using Status (or any other wallet) with your mnemonic phrase.
+
     - question: How secure is Keycard?
-      text: The security of the card is dependent upon the applet software that is used on the card. This applet is open source (link) and has been audited by a third party security auditing firm. From a hardware perspective, Keycard is a SE secure element with a very high level of hardware protection. It passes CC EAL5+ formal testing for its security evaluation.
+      text: The included Keycard applet is open source, and has been audited by a third party security firm. The Keycard hardware is a SE secure element with a very high level of hardware protection. It passes CC EAL5+ formal testing for its security evaluation. Other applets (i.e. manually installed to the Keycard) may not be secure.
 
 - setup:
   title: Setup
   list: 
     - question: How do I get going with Keycard and Status?
-      text: If you are a new Status user, then you just have to download Status, follow our onboarding flows, you will have to chose if you want to generate a new account or import one from a mnemonic sentence, and then chose to store it in your Keycard. From there, you will be asked to tap your Keycard and enter your pin whenever you want to login in Status, or sign a transaction.
+      text: Download Status, generate keys or import a pre-existing wallet, and choose to store it on your Keycard. After, you will be asked to tap your Keycard and enter your PIN whenever you login to Status or sign a transaction.
     
     - question: What is the PIN?
-      text: You will define your 6 digit PIN during the onboarding. You will need to remember this PIN since this will be asked each time your tap your card on the phone.
+      text: Your 6 digit PIN is chosen by you when you connect your Keycard to Status. You will have to enter the PIN when tapping your card, so remember it carefully (or save it in a password manager).
 
     - question: What are pairing code and PUK?
-      text: When you onboard with Status and Keycard, you will be provided a pairing code and PUK.. You have to write down these two pieces of data very carefully because they will never be presented to you again. Your pairing code will be needed when you want to use your Keycard with another phone or other app than Status. Your PUK code will be needed if you forget your PIN, in order to reset and change it.
+      text: When you set up Status and Keycard, you will be provided a pairing code and PUK. IMPORTANT: These codes will only be shown to you once, so write them down or save them to a password manager. Your pairing code allows you to use your Keycard with unpaired phones and apps. Your PUK code allows you to reset or change your PIN.
      
     - question: What is the mnemonic phrase?
-      text: Status accounts are generated with a master secret which can be represented with a list of words. When you generate a new Status account, you will be provided by this list of words. It is crucial that you write down this list of words somewhere safe. If you lose your Keycard, lose your PUK, or Pairing code together with your phone, it’s your only solution to access your funds.
+      text: Status accounts are generated with a master secret which can be represented with a list of words. When you generate a new Status account, you will be provided by this list of words. It is crucial that you write down this list of words somewhere safe. If you lose your Keycard, lose your PUK, or pairing code and phone, it’s the only way to recover your funds.
 
     - question: I already own a Status account and want to use it with my Keycard, how should I proceed?
-      text: from Status v1.11, logout from your account, and then select your account in the list, click '...', select 'Manage keys and storage' and then 'Move Keystore file', enter your seed and then selects Keycard. From there, you will be guided to set-up your new keycard and your account will be migrated on it. 
+      text: from Status v1.11, logout from your account, and then select your account in the list, click '...', select 'Manage keys and storage' and then 'Move Keystore file', enter your seed and then select Keycard. From there, you will be guided to set-up your new keycard and your account will be migrated on it. 
       
-    - question: Can I reinstall Keycard applet (advanced users only)?
-      text: If you’re an advanced user, or a developer, you might want to reinstall the Javacard applet on your Keycard. This will put back your card in the same state thzen when you first got it brand new (factory reset). You might want to do this if you’ve lost your PIN & PUK, or if your pairing slots on the card are all full. This operation will delete everything on our card. Do this at your own peril, and please make sure you have your 12 words mnemonic if you have an account on your card. There are several ways to do this. The best way is to have a USB contacted (not NFC) reader and a desktop computer. In that case you use or use our CLI tool (https://github.com/status-im/keycard-cli/releases) or a 3rd party (opensource) GUI tool (https://github.com/choppu/keycard-desktop/releases) to reinstall the applet. If you only have an Android smartphone with NFC, you can use Keycard Connect (https://github.com/status-im/keycard-connect/releases) to do this. This is however a dangerous operation and might destroy your card if connection is lost during the reinstallation. Make sure the card is firmly touching the phone and do not disconnect it until the “Tap your card” prompt doesn’t go away. On newer JCOP4 cards this takes less than a minute but on slower JCOP3 cards it can take several minutes. The applet itself, distributed as a standard Javacard cap file can be found here https://github.com/status-im/status-keycard/releases. You will need this regardless of the method you use to reinstall.
+    - question: Can I reinstall the Keycard applet (advanced users only)?
+      text: If you’re an advanced user, or a developer, you might want to reinstall the Javacard applet on your Keycard. This will factory reset your card. You might want to do this if you’ve lost your PIN & PUK, or if your pairing slots on the card are all full. IMPORTANT: This operation will delete everything on your card. Do this at your own risk, and please make sure you have your 12 word mnemonic phrase stored somewhere else if you have an account on your card. There are several ways to do this. The best way is to have a USB contacted (not NFC) reader and a desktop computer. In that case use our CLI tool (https://github.com/status-im/keycard-cli/releases) or a 3rd party (opensource) GUI tool (https://github.com/choppu/keycard-desktop/releases) to reinstall the applet. If you only have an Android smartphone with NFC, you can use Keycard Connect (https://github.com/status-im/keycard-connect/releases) to do this. This is a dangerous operation and might destroy your card if connection is lost during the reinstallation. Make sure the card is firmly touching the phone and do not disconnect it until the “Tap your card” prompt doesn’t go away. On newer JCOP4 cards this takes less than a minute but on slower JCOP3 cards it can take several minutes. The applet itself, distributed as a standard Javacard cap file can be found here https://github.com/status-im/status-keycard/releases. You will need this regardless of the method you use to reinstall.
 
 - other:
   title: Other questions
   list: 
     - question: I own one Keycard, can I use it with several phones, or several applications concurrently?
-      text: Yes you can. Your Keycard has one pairing code that can enable you to set-up 5 concurrent secure channels.
+      text: Yes. Your pairing code can enable you to set-up 5 secure connections.
     
     - question: I lost my PIN, what should I do?
-      text: If you make more then 3 wrong attempts of your PIN, you will be asked to enter your PUK to reset and change your PIN.
+      text: If you get your PIN incorrect more than 3 times, you will have to enter your PUK to reset and change your PIN.
 
     - question: I lost my PUK, what should I do?
-      text: If you lost your PUK and your PIN then you are in a pretty bad situation, you will never be able to use your Keycard. To recover your funds you should use your mnemonic words and generate the wallet again in Status or another wallet. If you are developer and lost your PIN and PUK, we might help you factory reset your Keycard, please reach out to https://join.status.im/chat/public/status-keycard
+      text: If you lost your PUK and your PIN your Keycard will not work. To recover your funds you should use your mnemonic words and generate the wallet again in Status or another wallet. If you are developer and lost your PIN and PUK, we might help you factory reset your Keycard, please reach out to https://join.status.im/chat/public/status-keycard
     
-    - question: I lost my Pairing code, what should I do?
-      text: If you lost your pairing code, you must make sure that you have noted down your mnemonic words. Without your pairing code and your mnemonic words you are at risk to lose access to your funds if you lose your phone.
+    - question: I lost my pairing code, what should I do?
+      text: Make sure your mnemonic words are stored somewhere safe and secure. Without a pairing code, your mnemonic phrase is required to recover your funds if you lose your phone.
 
     - question: My keycard pairing slots are full, what should I do?
-      text: If you have paired your keycard with more than 5 different devices then all the 5 pairing slots of your cards are full. There is for now no user interface within Status to free one of these slots. If you need to free one up you need to reinstall the applet (see related FAQ entry. This is a sensitive operation). As a suggestion, as soon as you get your Keycard (or restore it), pair it with Keycard Connect (https://github.com/status-im/keycard-connect/releases). If you do this, you will be able to unpair other clients without having to reinstall the applet. If you are developing with the Keycard, you can find the documentation of the unpairing command is here https://keycard.tech/docs/apdu/unpair.html
+      text: Your Keycard can only be paired with 5 devices. If your Keycard is paired with Keycard Connect (https://github.com/status-im/keycard-connect/releases), you can unpair the devices. If your Keycard is not paired with Keycard Connect, you will have to reinstall the applet to unpair devices. Note that this will factory reset your Keycard, and is a sensitive operation. See "Can I reinstall the Keycard applet (advanced users only)?" for details. For developers, see the documentation of the unpairing command here - https://keycard.tech/docs/apdu/unpair.html
    
     - question: I lost my mnemonic phrase, what should I do?
-      text: If you lost your mnemonic phrase for your current your account, you have to act because you are under the risk of losing all your funds at some point if you lose your Keycard or forget your PUK/Pairing code. You should immediately create a new wallet with a new mnemonic phrase and transfer your assets from your current account on it.
+      text: If you lost your mnemonic phrase for your current account, you should immediately create a new wallet with a new mnemonic phrase and transfer your assets from your current account to it. Your mnemonic phrase is required to recover your funds if you lose your Keycard or your PUK/pairing code.
       
     - question: I lost my keycard, what should I do?
-      text: If you lost your keycard, your funds are safe. To use your keycard on a phone you do not own (and thus haven't paired the keycard with) one needs your pairing code and your 6 digits pass code to access your funds. You can recover your funds with Status or any other wallet by using your mnemonic.  
+      text: If you lose your keycard, your funds are safe. Your pairing code and 6 digit passcode are both required to access your funds from a phone that isn't paired with your Keycard. Your funds can be recovered using Status (or any other wallet) with your mnemonic phrase.


### PR DESCRIPTION
Add missing links, update price, improve grammar

In some places I have changed the meaning and not just the structure of the text. will add comments where I think I have done this (for extra attention from maintainers) 

These are the two biggest changes in meaning
```
old: 
Moreover its form factor is very convenient to carry around. Keycard does not have a screen or keyboard, making it cost effective.
new: 
It's also convenient, lightweight, it fits in your wallet, pocket, phone case, practically anywhere.

old:
Status app can be used with Keycard and supports Ethereum assets (eth, erc-20, nfts).
new:
However, if you are using Keycard with Status you will be limited to the blockchains that Status supports.
```